### PR TITLE
Move emitting “connect” event to `connect` method

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -56,12 +56,6 @@ function Device(options) {
   this.mqtt = options.mqtt || new MQTT();
   this.mqtt.on('message', this.handleMessage.bind(this));
 
-  // Only want 'connect' to be emitted the first time. Every time after
-  // will only emit the reconnect event.
-  this.mqtt.once('connect', (function() {
-    this.emit('connect');
-  }).bind(this));
-
   this.mqtt.on('connect', this.handleConnect.bind(this));
 
   this.mqtt.on('reconnect', (function() {
@@ -102,7 +96,15 @@ Device.prototype.handleConnect = function() {
  * Connects to the Losant platform.
  */
 Device.prototype.connect = function(callback) {
-  this.mqtt.connect(this.options, callback);
+  var self = this;
+  this.mqtt.connect(this.options, function (error) {
+    if (!error) {
+      // Only want 'connect' to be emitted the first time. Every time after
+      // will only emit the reconnect event.
+      self.emit('connect');
+    }
+    callback(error);
+  });
 };
 
 /**


### PR DESCRIPTION
The MQTT class handles tracking state on if the connection has already completed or not.

Alternate proposal for issue #7 